### PR TITLE
feat(backend): harden socket auth and prevent duplicate active identity

### DIFF
--- a/packages/backend/src/contracts/schemas.ts
+++ b/packages/backend/src/contracts/schemas.ts
@@ -16,6 +16,7 @@ export const joinRoomSchema = z.object({
   roomId: z.string().regex(roomIdRegex, "roomId must be 3-64 chars [a-zA-Z0-9_-]"),
   rows: z.number().int().min(1).max(12).optional(),
   cols: z.number().int().min(1).max(12).optional(),
+  playerId: z.string().min(1).max(128).optional(),
 }).strict();
 
 export const makeMoveSchema = z.object({

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -23,6 +23,30 @@ function extractSocketToken(rawAuthToken: unknown, authorizationHeader: string |
   return null;
 }
 
+function buildGuestSocketUser(rawGuestId: unknown): JwtPayload | null {
+  if (typeof rawGuestId !== "string") {
+    return null;
+  }
+
+  const guestId = rawGuestId.trim();
+  if (!guestId) {
+    return null;
+  }
+
+  const safeGuest = guestId.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 64);
+  if (!safeGuest) {
+    return null;
+  }
+
+  return {
+    userId: `guest_${safeGuest}`,
+    username: `guest_${safeGuest}`,
+    email: `guest_${safeGuest}@squarexo.local`,
+    role: "guest",
+    tokenType: "access",
+  };
+}
+
 export type BackendServer = {
   io: IOServer;
   httpServer: ReturnType<typeof createServer>;
@@ -45,18 +69,26 @@ export function createBackendServer(env: AppEnv): BackendServer {
   }
   io.use((socket, next) => {
     const token = extractSocketToken(socket.handshake.auth?.token, socket.handshake.headers.authorization);
-    if (!token) {
+
+    if (token) {
+      const verified = tokenService.verifyAccessToken(token);
+      if (verified.error || !verified.payload) {
+        next(new Error(verified.error ?? "INVALID_TOKEN"));
+        return;
+      }
+
+      socket.data.user = verified.payload as JwtPayload;
+      next();
+      return;
+    }
+
+    const guestUser = buildGuestSocketUser(socket.handshake.auth?.playerId);
+    if (!guestUser) {
       next(new Error("MISSING_TOKEN"));
       return;
     }
 
-    const verified = tokenService.verifyAccessToken(token);
-    if (verified.error || !verified.payload) {
-      next(new Error(verified.error ?? "INVALID_TOKEN"));
-      return;
-    }
-
-    socket.data.user = verified.payload as JwtPayload;
+    socket.data.user = guestUser;
     next();
   });
 

--- a/packages/backend/src/socket/handler.ts
+++ b/packages/backend/src/socket/handler.ts
@@ -155,6 +155,17 @@ export function registerSocketHandlers(io: Server, options: HandlerOptions): voi
           });
         }
 
+        const hasActiveSameIdentity = [...room.socketToPlayerId.entries()].some(
+          ([trackedSocketId, trackedPlayerId]) => trackedSocketId !== socket.id && trackedPlayerId === playerId,
+        );
+        if (hasActiveSameIdentity) {
+          throw new ContractError(
+            ErrorCode.VALIDATION_ERROR,
+            "Player identity is already active in this room",
+            { roomId: room.roomId, playerId },
+          );
+        }
+
         const assignedPlayer = options.roomManager.assignSocket(room, socket.id, playerId);
         socketToRoom.set(socket.id, room.roomId);
         socket.join(room.roomId);


### PR DESCRIPTION
- Support guest identity fallback when JWT missing (buildGuestSocketUser)
- Allow playerId in join_room schema for backward compatibility
- Prevent multiple active sockets with same identity in one room
- Fixes dual-X/dual-O player assignment bug in online multiplayer

Changes:
- packages/backend/src/server.ts: Add guest identity middleware fallback
- packages/backend/src/socket/handler.ts: Guard duplicate active identity
- packages/backend/src/contracts/schemas.ts: Add optional playerId field
- packages/game-core/src/index.js: Sync chooseAIMove export